### PR TITLE
[ci] sync template files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "template-files",
   "version": "0.1.1",
-  "license": "MIT",
   "description": "Provide single point of truth for template files",
+  "license": "MIT",
+  "author": "trueberryless-org",
   "scripts": {
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile"
   },
-  "author": "trueberryless-org",
-  "packageManager": "pnpm@9.6.0",
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.9"
-  }
+  },
+  "packageManager": "pnpm@9.6.0"
 }


### PR DESCRIPTION
This PR syncs the specified GitHub template files from the [central repository](https://github.com/trueberryless-org/template-files).

### Changes:
- try sort package json - ([957a90e](https://github.com/trueberryless-org/template-files/commit/957a90ef8ece7e1c48e728d9efcb3314b6ed2d3e))
- package.json sort flow - ([b63f4e7](https://github.com/trueberryless-org/template-files/commit/b63f4e7a486d9b9d1166219c39932d7513b0e96a))
- i have to try the action first - ([8bcfa68](https://github.com/trueberryless-org/template-files/commit/8bcfa686bfd4fdc45e854c1f2bdc3761de914472))
- needs public github token - ([1ecc7c1](https://github.com/trueberryless-org/template-files/commit/1ecc7c19fe721f214305150337f98d663b968225))