### PR TITLE
[ci] sync template files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,16 @@
   "name": "template-files",
   "version": "0.1.3",
   "description": "Provide single point of truth for template files",
+  "homepage": "https://github.com/trueberryless-org/template-files",
+  "bugs": {
+    "url": "https://github.com/trueberryless-org/template-files/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trueberryless-org/template-files.git"
+  },
   "license": "MIT",
-  "author": "trueberryless-org",
+  "author": "trueberryless <trueberryless@gmail.com> (https://trueberryless.org)",
   "scripts": {
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile"
   },


### PR DESCRIPTION
This PR syncs the specified GitHub template files from the [central repository](https://github.com/trueberryless-org/template-files).

### Changes:
- Merge pull request #25 from trueberryless-org/changeset-release/main - ([a79e1a1](https://github.com/trueberryless-org/template-files/commit/a79e1a14b3cb1be4310b52142cad7c454d04f55c))
- add EOF to .gitignore - ([69ec8e1](https://github.com/trueberryless-org/template-files/commit/69ec8e1e407703383b6f7642bd1f50f6965f7f82))